### PR TITLE
build: Move var workarounds into build.sh

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,12 +2,6 @@ ARG MAJOR_VERSION="${MAJOR_VERSION:-stream10}"
 
 FROM quay.io/centos-bootc/centos-bootc:$MAJOR_VERSION
 
-# See https://github.com/centos-workstation/achillobator/issues/3
-RUN mkdir -p /var/roothome
-
-# Total hack to see if we can fix the /var/run symlink
-RUN ln -sf /run /var/run
-
 #Install codecs, Workstation, EPEL, CRB, etc.
 COPY build.sh /tmp/build.sh
 RUN chmod +x /tmp/build.sh &&\

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,11 @@
 
 set -euox pipefail
 
+# See https://github.com/centos-workstation/achillobator/issues/3
+mkdir -m 0700 -p /var/roothome
+# Fast track https://gitlab.com/fedora/bootc/base-images/-/merge_requests/71
+ln -sf /run /var/run
+
 dnf config-manager --set-enabled crb
 dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
 


### PR DESCRIPTION
Since we're not squashing by default we don't want to waste a whole layer for these tiny bits.

Also add the PR link for var/run which is in progress to being fixed in the next image.