### PR TITLE
feat: strip out unnecessary GNOME applications from @Workstation group

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,11 +12,56 @@ dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noar
 
 dnf -y install @multimedia gstreamer1-plugins-{bad-free,bad-free-libs,good,base} lame{,-libs} libjxl plymouth plymouth-system-theme
 
-dnf group install -y --nobest Workstation 
+# `dnf group info Workstation` without GNOME
+dnf group install -y --nobest \
+  -x console-login-helper-messages \
+  -x rsyslog* \
+  -x cockpit \
+  -x PackageKit \
+  -x PackageKit-command-not-found \
+   "Common NetworkManager submodules" \
+   "Core" \
+   "Fonts" \
+   "Guest Desktop Agents" \
+   "Hardware Support" \
+   "Printing Client" \
+   "Standard" \
+   "Workstation product core"
 
-dnf -y remove console-login-helper-messages cockpit-packagekit rsyslog
+# Minimal GNOME group. ("Multimedia" adds most of the packages from the GNOME group. This should clear those up too.)
+# In order to reproduce this, get the packages with `dnf group info GNOME`, install them manually with dnf install and see all the packages that are already installed.
+# Other than that, I've removed a few packages we didnt want, those being a few GUI applications.
+dnf -y install \
+  -x PackageKit \
+  -x PackageKit-command-not-found \
+  -x gnome-software-fedora-langpacks \
+   "NetworkManager-adsl" \
+   "centos-backgrounds" \
+   "gdm" \
+   "gnome-bluetooth" \
+   "gnome-color-manager" \
+   "gnome-control-center" \
+   "gnome-initial-setup" \
+   "gnome-remote-desktop" \
+   "gnome-session-wayland-session" \
+   "gnome-settings-daemon" \
+   "gnome-shell" \
+   "gnome-software" \
+   "gnome-user-docs" \
+   "gvfs-fuse" \
+   "gvfs-goa" \
+   "gvfs-gphoto2" \
+   "gvfs-mtp" \
+   "gvfs-smb" \
+   "libsane-hpaio" \
+   "nautilus" \
+   "orca" \
+   "ptyxis" \
+   "sane-backends-drivers-scanners" \
+   "xdg-desktop-portal-gnome" \
+   "xdg-user-dirs-gtk" \
+   "yelp-tools"
 
-dnf upgrade -y
 # This seems weirdly like a Schrödinger's issue. Removing the kernel here fails some builds and not removing it actually-
 # breaks some stuff? I dont know exactly what to do here.
 # FIXME: Figure out if this is necessary


### PR DESCRIPTION
This removes alllll of the GUI applications we get by installing @Workstation.
It also removes packagekit, rsyslog and cockpit from the base.

Fixes: #5
