### PR TITLE
chore: remove crontabs as a default

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,8 @@ dnf -y install @multimedia gstreamer1-plugins-{bad-free,bad-free-libs,good,base}
 dnf group install -y --nobest \
   -x rsyslog* \
   -x cockpit \
+  -x cronie* \
+  -x crontabs \
   -x PackageKit \
   -x PackageKit-command-not-found \
    "Common NetworkManager submodules" \


### PR DESCRIPTION
I believe we should not ship crontabs as a default. This just removes cronie the default crontab configs