### PR TITLE
chore: add systemd container

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,8 @@ ln -sf /run /var/run
 dnf config-manager --set-enabled crb
 dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
 
+dnf -y install systemd-container
+
 dnf -y install @multimedia gstreamer1-plugins-{bad-free,bad-free-libs,good,base} lame{,-libs} libjxl plymouth plymouth-system-theme fwupd
 
 # `dnf group info Workstation` without GNOME


### PR DESCRIPTION
Sadly I believe this is going to be required by UUPD. Systemd-container provides `machinectl` which we are using for remote user command execution by the Brew, Flatpak and Distrobox modules.
  